### PR TITLE
feat: only support a subset of google auth options

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,9 @@ Defined in the order that they compose into an "Image":
         the name of the base image. these are image specifiers just like you would pass to other container tools.
     - targetImage
         the name of the image you're going to be saving to. calls to image.save() will replace this image.
-    - options (ImageOptions)
-        - auth - {"auth":{'container registry cname':{registry credentials}}}
-            - see <a href="#docker-registry-auth">Detailed auth information</a> for more about how to authenticate with any registry.
+    - options
+        - see <a href="#ImageOptions">ImageOptions</a> for options.
+        - see <a href="#docker-registry-auth">Detailed auth information</a> for more about how to authenticate with any registry.
 
 - `image.addFiles({[targetDirectory]:localDirectory},options): Promise<..>`
 
@@ -251,6 +251,18 @@ Defined in the order that they compose into an "Image":
     - default new Date(). set to Date if you want to set
 - `customFile.mtime`
     - default new Date(). set to Date if you want to set
+
+- <a name="ImageOptions">ImageOptions</a>
+    - ImageOptions is an object with the optional key auth. if `auth` is provided it will be used to provided authentication metadata for calls to the specified registry. If there is no authentication provider for your particular registry you can an object with the key token as it's value.
+    - `{auth:{'my.registry.io':{token?:string}}}`
+    - default support for docker.io and google container registry (gcr.io) are built in.
+    - if your registry has `gcr.io` in it you can pass <a href="#GCRAuthOptions">additional options</a>.
+
+- <a name="GCRAuthOptions">GCRAuthOptions</a>
+    - {credentials?:{private_key:string,client_email:string},keyFilename?:string,token?:string}
+    - if no options are provided it falls back to using GOOGLE_APPLICATION_CREDENTIALS to provide the keyFilename
+    - the values for crdentials normally come from a key file like you would pass to keyFilename and download as service account credentials.
+
 
 ### docker registry auth
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "registry": "https://wombat-dressing-room.appspot.com/container-image-builder/_ns"
   },
   "nyc": {
-    "extension":".ts",
-    "incolude":"src/**/*.ts"
+    "extension":".ts"
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,5 +47,9 @@
   },
   "publishConfig": {
     "registry": "https://wombat-dressing-room.appspot.com/container-image-builder/_ns"
+  },
+  "nyc": {
+    "extension":".ts",
+    "incolude":"src/**/*.ts"
   }
 }

--- a/src/auth/gcr.ts
+++ b/src/auth/gcr.ts
@@ -18,17 +18,31 @@ import * as request from 'request';
 import {DockerAuthResult} from '../credentials-helper';
 import {ImageLocation} from '../image-specifier';
 
+export type GCRAuthOptions = {
+  token?: string,
+  keyFilename?: string,
+  credentials?: {private_key: string, client_email: string}
+};
 
 // i dont know what the options will be yet
 // tslint:disable-next-line:no-any
 export const handler = async(
     image: ImageLocation, scope: string,
-    options: GoogleAuthOptions): Promise<DockerAuthResult> => {
+    options: GCRAuthOptions): Promise<DockerAuthResult> => {
   // google auth options:
   // https://github.com/googleapis/google-auth-library-nodejs/blob/master/src/auth/googleauth.ts#L58
 
+  // client is configured with a valid token from auth.getToken() already. trust
+  // it works.
+  if (options.token) {
+    return {Username: '_token', Secret: options.token, token: options.token};
+  }
+
   // expects GOOGLE_APPLICATION_CREDENTIALS env or options
-  const resolvedOptions: GoogleAuthOptions = options || {};
+  const resolvedOptions: GoogleAuthOptions = {
+    credentials: options.credentials,
+    keyFilename: options.keyFilename
+  };
   if (!('scopes' in resolvedOptions)) {
     // Depending on `scope` that describes push and/or pull
     // capabilities, the Google services scope need to be specified to

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,19 +13,16 @@
 // limitations under the License.
 //
 import * as crypto from 'crypto';
-import {GoogleAuthOptions} from 'google-auth-library';
 import * as retry from 'p-retry';
 import * as zlib from 'zlib';
 
 import {handler as dockerAuth} from './auth/dockerio';
-import {handler as gcrAuth} from './auth/gcr';
+import {GCRAuthOptions, handler as gcrAuth} from './auth/gcr';
 import {DockerAuthResult, DockerCredentialHelpers} from './credentials-helper';
 import {ImageLocation, parse as parseSpecifier} from './image-specifier';
 import * as packer from './packer';
 import {pending, PendingTracker} from './pending';
 import {ImageConfig, ManifestV2, RegistryClient} from './registry';
-
-const tar = require('tar');
 
 // expose plain registry client.
 export {RegistryClient} from './registry';
@@ -463,7 +460,7 @@ export const pack = packer.pack;
 export const CustomFile = packer.CustomFile;
 
 export interface AuthConfig {
-  'gcr.io'?: GoogleAuthOptions;
+  'gcr.io'?: GCRAuthOptions;
   // tslint:disable-next-line:no-any
   'docker.io'?: any;
   // tslint:disable-next-line:no-any


### PR DESCRIPTION
BREAKING CHANGE: drop support for passing GoogleAuthOptions directly to
google-auth-library. only suppports GOOGLE_APPLICATION_CREDENTIALS env,
credentials, and keyFilename

updated docs