### PR TITLE
fix: incorrect parsing of dockerhub namespaces

### DIFF
--- a/src/image-specifier.ts
+++ b/src/image-specifier.ts
@@ -49,7 +49,7 @@ export const parse = (specifier: string): ImageLocation => {
   }
 
   if (registry === DEFAULT_REGISTRY_ALIAS || !registry) {
-    namespace = 'library';
+    namespace = namespace || 'library';
     registry = 'index.docker.io';
   }
 

--- a/test/image-specifier.ts
+++ b/test/image-specifier.ts
@@ -71,6 +71,17 @@ const specifiers: Array<{specifier: string, result: ImageLocation}> = [
       tag: 'latest',
       digest: undefined
     }
+  },
+  {
+    specifier: 'docker.io/usernamespace/hello-world',
+    result: {
+      protocol: 'https',
+      registry: 'index.docker.io',
+      namespace: 'usernamespace',
+      image: 'hello-world',
+      tag: 'latest',
+      digest: undefined
+    }
   }
 ];
 


### PR DESCRIPTION
When parsing Dockerhub specifiers the namespace is always replaced by the default namespace: `library`. This pr fixes that.